### PR TITLE
Add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -149,6 +149,8 @@ typings/
 # dotenv environment variables file
 .env
 
+# Babel config file
+.babelrc
 
 ### VisualStudioCode ###
 .vscode/*


### PR DESCRIPTION
Because the `.babelrc` file is included in the published package but the preset listed therein is a devDependency, any babel compilation which parses this config file will throw due to the preset not being installed. Seeing as the code is compiled pre-publish removing the babel config file has no impact on functionality.