### PR TITLE
feat: pass HTML serializer children as string

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { FilledLinkToDocumentField } from "@prismicio/types";
 import {
 	RichTextFunctionSerializer,
 	RichTextMapSerializer,
+	RichTextMapSerializerFunction,
 } from "@prismicio/richtext";
 
 /**
@@ -23,11 +24,52 @@ export type LinkResolverFunction<ReturnType = string> = (
  *
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
-export type HTMLFunctionSerializer = RichTextFunctionSerializer<string>;
+export type HTMLFunctionSerializer = (
+	type: Parameters<RichTextFunctionSerializer<string>>[0],
+	node: Parameters<RichTextFunctionSerializer<string>>[1],
+	text: Parameters<RichTextFunctionSerializer<string>>[2],
+	children: Parameters<RichTextFunctionSerializer<string>>[3][number],
+	key: Parameters<RichTextFunctionSerializer<string>>[4],
+) => string | null | undefined;
 
 /**
  * Serializes a node from a rich text or title field with a map to HTML
  *
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
-export type HTMLMapSerializer = RichTextMapSerializer<string>;
+export type HTMLMapSerializer = {
+	[P in keyof RichTextMapSerializer<string>]: (payload: {
+		type: Parameters<HTMLMapSerializerFunction<P>>[0]["type"];
+		node: Parameters<HTMLMapSerializerFunction<P>>[0]["node"];
+		text: Parameters<HTMLMapSerializerFunction<P>>[0]["text"];
+		children: Parameters<HTMLMapSerializerFunction<P>>[0]["children"][number];
+		key: Parameters<HTMLMapSerializerFunction<P>>[0]["key"];
+	}) => string | null | undefined;
+};
+
+type HTMLMapSerializerFunction<P extends keyof RichTextMapSerializer<string>> =
+	RichTextMapSerializerFunction<
+		string,
+		ExtractRTNodeType<RichTextMapSerializer<string>[P]>,
+		ExtractRTTextType<RichTextMapSerializer<string>[P]>
+	>;
+
+type ExtractRTNodeType<T> = T extends RichTextMapSerializerFunction<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	any,
+	infer U,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	any
+>
+	? U
+	: never;
+
+type ExtractRTTextType<T> = T extends RichTextMapSerializerFunction<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	any,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	any,
+	infer U
+>
+	? U
+	: never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,9 @@ export type LinkResolverFunction<ReturnType = string> = (
 /**
  * Serializes a node from a rich text or title field with a function to HTML
  *
+ * Unlike a typical `@prismicio/richtext` function serializer, this serializer
+ * converts the `children` argument to a single string rather than an array of strings.
+ *
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
 export type HTMLFunctionSerializer = (
@@ -35,6 +38,9 @@ export type HTMLFunctionSerializer = (
 /**
  * Serializes a node from a rich text or title field with a map to HTML
  *
+ * Unlike a typical `@prismicio/richtext` map serializer, this serializer
+ * converts the `children` property to a single string rather than an array of strings.
+ *
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
 export type HTMLMapSerializer = {
@@ -47,14 +53,26 @@ export type HTMLMapSerializer = {
 	}) => string | null | undefined;
 };
 
-type HTMLMapSerializerFunction<P extends keyof RichTextMapSerializer<string>> =
-	RichTextMapSerializerFunction<
-		string,
-		ExtractRTNodeType<RichTextMapSerializer<string>[P]>,
-		ExtractRTTextType<RichTextMapSerializer<string>[P]>
-	>;
+/**
+ * A {@link RichTextMapSerializerFunction} type specifically for {@link HTMLMapSerializer}.
+ *
+ * @typeParam BlockName - The serializer's Rich Text block type.
+ */
+type HTMLMapSerializerFunction<
+	BlockType extends keyof RichTextMapSerializer<string>,
+> = RichTextMapSerializerFunction<
+	string,
+	ExtractNodeGeneric<RichTextMapSerializer<string>[BlockType]>,
+	ExtractTextTypeGeneric<RichTextMapSerializer<string>[BlockType]>
+>;
 
-type ExtractRTNodeType<T> = T extends RichTextMapSerializerFunction<
+/**
+ * Returns the `Node` generic from {@link RichTextMapSerializerFunction}.
+ *
+ * @typeParam T - The `RichTextMapSerializerFunction` containing the needed
+ *   `Node` generic.
+ */
+type ExtractNodeGeneric<T> = T extends RichTextMapSerializerFunction<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	any,
 	infer U,
@@ -64,7 +82,13 @@ type ExtractRTNodeType<T> = T extends RichTextMapSerializerFunction<
 	? U
 	: never;
 
-type ExtractRTTextType<T> = T extends RichTextMapSerializerFunction<
+/**
+ * Returns the `TextType` generic from {@link RichTextMapSerializerFunction}.
+ *
+ * @typeParam T - The `RichTextMapSerializerFunction` containing the needed
+ *   `TextType` generic.
+ */
+type ExtractTextTypeGeneric<T> = T extends RichTextMapSerializerFunction<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	any,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/__testutils__/htmlFunctionSerializer.ts
+++ b/test/__testutils__/htmlFunctionSerializer.ts
@@ -9,7 +9,7 @@ export const htmlFunctionSerializer: HTMLFunctionSerializer = (
 ) => {
 	switch (node.type) {
 		case Element.heading1: {
-			return `<h2>${children.join("")}</h2>`;
+			return `<h2>${children}</h2>`;
 		}
 	}
 

--- a/test/__testutils__/htmlMapSerializer.ts
+++ b/test/__testutils__/htmlMapSerializer.ts
@@ -1,5 +1,5 @@
 import { HTMLMapSerializer } from "../../src";
 
 export const htmlMapSerializer: HTMLMapSerializer = {
-	heading1: ({ children }) => `<h2>${children.join("")}</h2>`,
+	heading1: ({ children }) => `<h2>${children}</h2>`,
 };

--- a/test/__testutils__/htmlMapSerializer.ts
+++ b/test/__testutils__/htmlMapSerializer.ts
@@ -2,4 +2,6 @@ import { HTMLMapSerializer } from "../../src";
 
 export const htmlMapSerializer: HTMLMapSerializer = {
 	heading1: ({ children }) => `<h2>${children}</h2>`,
+	// `undefined` serializers should be treated the same as not including it.
+	heading2: undefined,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR changes behavior with custom Rich Text HTML serializers. Rather than pass children as an array of strings, we can pass children as a concatenated string. This is done under the assumption that since we are returning HTML, a single string is always desired.

This saves the user the step of calling `String.prototype.join` themselves.

The following HTML serializers are now valid:

```typescript
export const htmlMapSerializer = {
	heading1: ({ children }) => `<h2>${children}</h2>`,
};

export const htmlFunctionSerializer: HTMLFunctionSerializer = (
	_type,
	node,
	_text,
	children,
) => {
	switch (node.type) {
		case Element.heading1: {
			return `<h2>${children}</h2>`;
		}
	}

	return null;
};
```

Without this PR, `children` would need to be converted to a string via `children.join('')`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
