### PR TITLE
fix: prioritize Link Resolver over Route Resolver

### DIFF
--- a/src/asLink.ts
+++ b/src/asLink.ts
@@ -34,17 +34,24 @@ export const asLink = <LinkResolverFunctionReturnType = string>(
 		case LinkType.Web:
 			return "url" in linkField ? linkField.url : null;
 
-		case LinkType.Document:
-			if ("url" in linkField && linkField.url) {
-				// When using `apiOptions.routes`...
-				return linkField.url;
-			} else if ("id" in linkField) {
-				// ...when not...
-				return linkResolver ? linkResolver(linkField) : null;
-			} else {
-				// ...when empty
-				return null;
+		case LinkType.Document: {
+			if ("id" in linkField && linkResolver) {
+				// When using Link Resolver...
+				const resolvedURL = linkResolver(linkField);
+
+				if (resolvedURL != null) {
+					return resolvedURL;
+				}
 			}
+
+			if ("url" in linkField && linkField.url) {
+				// When using Route Resolver...
+				return linkField.url;
+			}
+
+			// When empty or Link Resolver and Route Resolver are not used...
+			return null;
+		}
 
 		case LinkType.Any:
 		default:

--- a/test/asLink.test.ts
+++ b/test/asLink.test.ts
@@ -37,7 +37,7 @@ test("returns null when link field is empty", (t) => {
 	t.is(asLink(field, linkResolver), null);
 });
 
-test("resolves a link to document field", (t) => {
+test("resolves a link to document field without Route Resolver", (t) => {
 	const field = {
 		id: "XvoFFREAAM0WGBng",
 		type: "page",
@@ -49,23 +49,61 @@ test("resolves a link to document field", (t) => {
 		isBroken: false,
 	};
 
-	t.is(asLink(field, linkResolver), "/test");
+	t.is(
+		asLink(field),
+		null,
+		"returns null if both Link Resolver and Route Resolver are not used",
+	);
+	t.is(
+		asLink(field, linkResolver),
+		"/test",
+		"uses Link Resolver URL if Link Resolver returns a non-nullish value",
+	);
+	t.is(
+		asLink(field, () => undefined),
+		null,
+		"returns null if Link Resolver returns undefined",
+	);
+	t.is(
+		asLink(field, () => null),
+		null,
+		"returns null if Link Resolver returns null",
+	);
 });
 
-test("resolves a link to document field with `apiOptions.routes`", (t) => {
+test("resolves a link to document field with Route Resolver", (t) => {
 	const field = {
 		id: "XvoFFREAAM0WGBng",
 		type: "page",
 		tags: [],
 		slug: "slug",
 		lang: "en-us",
-		uid: "test",
-		url: "/test",
+		uid: "uid",
+		url: "url",
 		link_type: LinkType.Document,
 		isBroken: false,
 	};
 
-	t.is(asLink(field, linkResolver), "/test");
+	t.is(
+		asLink(field),
+		field.url,
+		"uses Route Resolver URL if Link Resolver is not given",
+	);
+	t.is(
+		asLink(field, () => "link-resolver-value"),
+		"link-resolver-value",
+		"uses Link Resolver URL if Link Resolver returns a non-nullish value",
+	);
+	t.is(
+		asLink(field, () => undefined),
+		field.url,
+		"uses Route Resolver URL if Link Resolver returns undefined",
+	);
+	t.is(
+		asLink(field, () => null),
+		field.url,
+		"uses Route Resolver URL if Link Resolver returns null",
+	);
 });
 
 test("returns null when given a document field and linkResolver is not provided ", (t) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR fixes the order in which `asLink` resolves document URLs. It gives priority to the Link Resolver (if given) over the Route Resolver.

It also falls back to the Route Resolver value if the Link Resolver returns a nullish value.

This allows a user to use Route Resolvers for most links but provide a Link Resolver for specific overrides (like overriding `/home` to `/`).

**Before this PR:**
1. If a Route Resolver is used (i.e. `field.url` is populated), return `field.url`. Stop here.
2. If a Link Resolver is given, return the resolver's return value. Stop here.
3. If neither a Route Resolver nor Link Resolver is used, return null. Stop here.

**After this PR:**
1. If a Link Resolver is given, return the resolver's return value. If the return value is nullish, don't return and continue…
2. If a Route Resolver is used (i.e. `field.url` is populated), return `field.url`. Otherwise…
3. If neither a Route Resolver nor Link Resolver is used, return null. Stop here.

**Note**: The documentation already reflects this behavior so I think it was just implemented in the wrong order. See: https://prismic.io/docs/core-concepts/link-resolver-route-resolver#if-you-include-both

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐹
