### PR TITLE
feat: narrow return types when field is known

### DIFF
--- a/src/asDate.ts
+++ b/src/asDate.ts
@@ -1,6 +1,16 @@
 import type { DateField, TimestampField } from "@prismicio/types";
 
 /**
+ * The return type of `asDate()`.
+ */
+type AsDateReturnType<Field extends DateField | TimestampField> =
+	Field extends DateField<"empty">
+		? null
+		: Field extends TimestampField<"empty">
+		? null
+		: Date;
+
+/**
  * Transforms a date or timestamp field into a JavaScript Date object
  *
  * @param dateOrTimestampField - A date or timestamp field from Prismic
@@ -8,11 +18,11 @@ import type { DateField, TimestampField } from "@prismicio/types";
  * @returns A Date object, null if provided date is falsy
  * @see Templating date field from Prismic {@link https://prismic.io/docs/technologies/templating-date-field-javascript}
  */
-export const asDate = (
-	dateOrTimestampField: DateField | TimestampField,
-): Date | null => {
+export const asDate = <Field extends DateField | TimestampField>(
+	dateOrTimestampField: Field,
+): AsDateReturnType<Field> => {
 	if (!dateOrTimestampField) {
-		return null;
+		return null as AsDateReturnType<Field>;
 	}
 
 	// If field is a timestamp field...
@@ -30,9 +40,9 @@ export const asDate = (
 		 */
 		return new Date(
 			dateOrTimestampField.replace(/(\+|-)(\d{2})(\d{2})$/, ".000$1$2:$3"),
-		);
+		) as AsDateReturnType<Field>;
 	} else {
 		// ...else field is a date field
-		return new Date(dateOrTimestampField);
+		return new Date(dateOrTimestampField) as AsDateReturnType<Field>;
 	}
 };

--- a/src/asDate.ts
+++ b/src/asDate.ts
@@ -5,11 +5,7 @@ import type { DateField, TimestampField } from "@prismicio/types";
  */
 type AsDateReturnType<
 	Field extends DateField | TimestampField | null | undefined,
-> = Field extends DateField<"filled">
-	? Date
-	: Field extends TimestampField<"filled">
-	? Date
-	: null;
+> = Field extends DateField<"filled"> | TimestampField<"filled"> ? Date : null;
 
 /**
  * Transforms a date or timestamp field into a JavaScript Date object

--- a/src/asDate.ts
+++ b/src/asDate.ts
@@ -3,12 +3,13 @@ import type { DateField, TimestampField } from "@prismicio/types";
 /**
  * The return type of `asDate()`.
  */
-type AsDateReturnType<Field extends DateField | TimestampField> =
-	Field extends DateField<"empty">
-		? null
-		: Field extends TimestampField<"empty">
-		? null
-		: Date;
+type AsDateReturnType<
+	Field extends DateField | TimestampField | null | undefined,
+> = Field extends DateField<"filled">
+	? Date
+	: Field extends TimestampField<"filled">
+	? Date
+	: null;
 
 /**
  * Transforms a date or timestamp field into a JavaScript Date object
@@ -18,7 +19,9 @@ type AsDateReturnType<Field extends DateField | TimestampField> =
  * @returns A Date object, null if provided date is falsy
  * @see Templating date field from Prismic {@link https://prismic.io/docs/technologies/templating-date-field-javascript}
  */
-export const asDate = <Field extends DateField | TimestampField>(
+export const asDate = <
+	Field extends DateField | TimestampField | null | undefined,
+>(
 	dateOrTimestampField: Field,
 ): AsDateReturnType<Field> => {
 	if (!dateOrTimestampField) {

--- a/src/asHTML.ts
+++ b/src/asHTML.ts
@@ -108,6 +108,12 @@ const wrapMapSerializerWithStringChildren = (
 };
 
 /**
+ * The return type of `asHTML()`.
+ */
+type AsHTMLReturnType<MaybeField extends RichTextField | null | undefined> =
+	MaybeField extends RichTextField ? string : null;
+
+/**
  * Serializes a rich text or title field to an HTML string
  *
  * @param richTextField - A rich text or title field from Prismic
@@ -119,11 +125,11 @@ const wrapMapSerializerWithStringChildren = (
  * @returns HTML equivalent of the provided rich text or title field
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
-export const asHTML = (
-	richTextField: RichTextField | null | undefined,
+export const asHTML = <MaybeField extends RichTextField | null | undefined>(
+	richTextField: MaybeField,
 	linkResolver?: LinkResolverFunction<string> | null,
 	htmlSerializer?: HTMLFunctionSerializer | HTMLMapSerializer | null,
-): string | null => {
+): AsHTMLReturnType<MaybeField> => {
 	if (richTextField) {
 		let serializer: RichTextFunctionSerializer<string>;
 		if (htmlSerializer) {
@@ -138,8 +144,10 @@ export const asHTML = (
 			serializer = createDefaultHTMLSerializer(linkResolver);
 		}
 
-		return serialize(richTextField, serializer).join("");
+		return serialize(richTextField, serializer).join(
+			"",
+		) as AsHTMLReturnType<MaybeField>;
 	} else {
-		return null;
+		return null as AsHTMLReturnType<MaybeField>;
 	}
 };

--- a/src/asHTML.ts
+++ b/src/asHTML.ts
@@ -110,8 +110,8 @@ const wrapMapSerializerWithStringChildren = (
 /**
  * The return type of `asHTML()`.
  */
-type AsHTMLReturnType<MaybeField extends RichTextField | null | undefined> =
-	MaybeField extends RichTextField ? string : null;
+type AsHTMLReturnType<Field extends RichTextField | null | undefined> =
+	Field extends RichTextField ? string : null;
 
 /**
  * Serializes a rich text or title field to an HTML string
@@ -125,11 +125,11 @@ type AsHTMLReturnType<MaybeField extends RichTextField | null | undefined> =
  * @returns HTML equivalent of the provided rich text or title field
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
-export const asHTML = <MaybeField extends RichTextField | null | undefined>(
-	richTextField: MaybeField,
+export const asHTML = <Field extends RichTextField | null | undefined>(
+	richTextField: Field,
 	linkResolver?: LinkResolverFunction<string> | null,
 	htmlSerializer?: HTMLFunctionSerializer | HTMLMapSerializer | null,
-): AsHTMLReturnType<MaybeField> => {
+): AsHTMLReturnType<Field> => {
 	if (richTextField) {
 		let serializer: RichTextFunctionSerializer<string>;
 		if (htmlSerializer) {
@@ -146,8 +146,8 @@ export const asHTML = <MaybeField extends RichTextField | null | undefined>(
 
 		return serialize(richTextField, serializer).join(
 			"",
-		) as AsHTMLReturnType<MaybeField>;
+		) as AsHTMLReturnType<Field>;
 	} else {
-		return null as AsHTMLReturnType<MaybeField>;
+		return null as AsHTMLReturnType<Field>;
 	}
 };

--- a/src/asImagePixelDensitySrcSet.ts
+++ b/src/asImagePixelDensitySrcSet.ts
@@ -10,21 +10,22 @@ import { imageThumbnail as isImageThumbnailFilled } from "./isFilled";
 /**
  * The return type of `asImagePixelDensitySrcSet()`.
  */
-type AsImagePixelDensitySrcSetReturnType<Field extends ImageFieldImage> =
-	Field extends ImageFieldImage<"empty">
-		? null
-		: {
-				/**
-				 * The Image field's image URL with Imgix URL parameters (if given).
-				 */
-				src: string;
+type AsImagePixelDensitySrcSetReturnType<
+	Field extends ImageFieldImage | null | undefined,
+> = Field extends ImageFieldImage<"filled">
+	? {
+			/**
+			 * The Image field's image URL with Imgix URL parameters (if given).
+			 */
+			src: string;
 
-				/**
-				 * A pixel-densitye-based `srcset` attribute value for the Image field's
-				 * image with Imgix URL parameters (if given).
-				 */
-				srcset: string;
-		  };
+			/**
+			 * A pixel-densitye-based `srcset` attribute value for the Image field's
+			 * image with Imgix URL parameters (if given).
+			 */
+			srcset: string;
+	  }
+	: null;
 
 /**
  * Creates a pixel-density-based `srcset` from an Image field with optional
@@ -56,12 +57,14 @@ type AsImagePixelDensitySrcSetReturnType<Field extends ImageFieldImage> =
  *   parameters (if given). If the Image field is empty, `null` is returned.
  * @see Imgix URL parameters reference: https://docs.imgix.com/apis/rendering
  */
-export const asImagePixelDensitySrcSet = <Field extends ImageFieldImage>(
+export const asImagePixelDensitySrcSet = <
+	Field extends ImageFieldImage | null | undefined,
+>(
 	field: Field,
 	params: Omit<BuildPixelDensitySrcSetParams, "pixelDensities"> &
 		Partial<Pick<BuildPixelDensitySrcSetParams, "pixelDensities">> = {},
 ): AsImagePixelDensitySrcSetReturnType<Field> => {
-	if (isImageThumbnailFilled(field)) {
+	if (field && isImageThumbnailFilled(field)) {
 		const { pixelDensities = [1, 2, 3], ...imgixParams } = params;
 
 		return {

--- a/src/asImageSrc.ts
+++ b/src/asImageSrc.ts
@@ -6,8 +6,8 @@ import { imageThumbnail as isImageThumbnailFilled } from "./isFilled";
 /**
  * The return type of `asImageSrc()`.
  */
-type AsImageSrcReturnType<Field extends ImageFieldImage> =
-	Field extends ImageFieldImage<"empty"> ? null : string;
+type AsImageSrcReturnType<Field extends ImageFieldImage | null | undefined> =
+	Field extends ImageFieldImage<"filled"> ? string : null;
 
 /**
  * Returns the URL of an Image field with optional image transformations (via
@@ -28,11 +28,11 @@ type AsImageSrcReturnType<Field extends ImageFieldImage> =
  *   If the Image field is empty, `null` is returned.
  * @see Imgix URL parameters reference: https://docs.imgix.com/apis/rendering
  */
-export const asImageSrc = <Field extends ImageFieldImage>(
+export const asImageSrc = <Field extends ImageFieldImage | null | undefined>(
 	field: Field,
 	params: ImgixURLParams = {},
 ): AsImageSrcReturnType<Field> => {
-	if (isImageThumbnailFilled(field)) {
+	if (field && isImageThumbnailFilled(field)) {
 		return buildURL(field.url, params) as AsImageSrcReturnType<Field>;
 	} else {
 		return null as AsImageSrcReturnType<Field>;

--- a/src/asImageWidthSrcSet.ts
+++ b/src/asImageWidthSrcSet.ts
@@ -10,21 +10,22 @@ import { imageThumbnail as isImageThumbnailFilled } from "./isFilled";
 /**
  * The return type of `asImageWidthSrcSet()`.
  */
-type AsImageWidthSrcSetReturnType<Field extends ImageFieldImage> =
-	Field extends ImageFieldImage<"empty">
-		? null
-		: {
-				/**
-				 * The Image field's image URL with Imgix URL parameters (if given).
-				 */
-				src: string;
+type AsImageWidthSrcSetReturnType<
+	Field extends ImageFieldImage | null | undefined,
+> = Field extends ImageFieldImage<"filled">
+	? {
+			/**
+			 * The Image field's image URL with Imgix URL parameters (if given).
+			 */
+			src: string;
 
-				/**
-				 * A width-based `srcset` attribute value for the Image field's image
-				 * with Imgix URL parameters (if given).
-				 */
-				srcset: string;
-		  };
+			/**
+			 * A width-based `srcset` attribute value for the Image field's image with
+			 * Imgix URL parameters (if given).
+			 */
+			srcset: string;
+	  }
+	: null;
 
 /**
  * Creates a width-based `srcset` from an Image field with optional image
@@ -60,12 +61,14 @@ type AsImageWidthSrcSetReturnType<Field extends ImageFieldImage> =
  *   parameters (if given). If the Image field is empty, `null` is returned.
  * @see Imgix URL parameters reference: https://docs.imgix.com/apis/rendering
  */
-export const asImageWidthSrcSet = <Field extends ImageFieldImage>(
+export const asImageWidthSrcSet = <
+	Field extends ImageFieldImage | null | undefined,
+>(
 	field: Field,
 	params: Omit<BuildWidthSrcSetParams, "widths"> &
 		Partial<Pick<BuildWidthSrcSetParams, "widths">> = {},
 ): AsImageWidthSrcSetReturnType<Field> => {
-	if (isImageThumbnailFilled(field)) {
+	if (field && isImageThumbnailFilled(field)) {
 		const { widths = [640, 828, 1200, 2048, 3840], ...urlParams } = params;
 		const {
 			url,

--- a/src/asLink.ts
+++ b/src/asLink.ts
@@ -20,13 +20,11 @@ type AsLinkReturnType<
 		| PrismicDocument
 		| null
 		| undefined,
-> = Field extends FilledLinkToWebField
-	? LinkResolverFunctionReturnType | string | null
-	: Field extends FilledLinkToMediaField
-	? LinkResolverFunctionReturnType | string | null
-	: Field extends FilledLinkToDocumentField
-	? LinkResolverFunctionReturnType | string | null
-	: Field extends PrismicDocument
+> = Field extends
+	| FilledLinkToWebField
+	| FilledLinkToMediaField
+	| FilledLinkToDocumentField
+	| PrismicDocument
 	? LinkResolverFunctionReturnType | string | null
 	: null;
 

--- a/src/asLink.ts
+++ b/src/asLink.ts
@@ -1,4 +1,12 @@
-import { LinkField, LinkType, PrismicDocument } from "@prismicio/types";
+import {
+	FilledLinkToDocumentField,
+	FilledLinkToMediaField,
+	FilledLinkToWebField,
+	LinkField,
+	LinkType,
+	PrismicDocument,
+} from "@prismicio/types";
+
 import { documentToLinkField } from "./documentToLinkField";
 import { LinkResolverFunction } from "./types";
 
@@ -7,10 +15,20 @@ import { LinkResolverFunction } from "./types";
  */
 type AsLinkReturnType<
 	LinkResolverFunctionReturnType = string,
-	Field extends LinkField | PrismicDocument = LinkField | PrismicDocument,
-> = Field extends LinkField<"empty">
-	? null
-	: LinkResolverFunctionReturnType | string | null;
+	Field extends LinkField | PrismicDocument | null | undefined =
+		| LinkField
+		| PrismicDocument
+		| null
+		| undefined,
+> = Field extends FilledLinkToWebField
+	? LinkResolverFunctionReturnType | string | null
+	: Field extends FilledLinkToMediaField
+	? LinkResolverFunctionReturnType | string | null
+	: Field extends FilledLinkToDocumentField
+	? LinkResolverFunctionReturnType | string | null
+	: Field extends PrismicDocument
+	? LinkResolverFunctionReturnType | string | null
+	: null;
 
 /**
  * Resolves any type of link field or document to a URL
@@ -26,7 +44,11 @@ type AsLinkReturnType<
  */
 export const asLink = <
 	LinkResolverFunctionReturnType = string,
-	Field extends LinkField | PrismicDocument = LinkField | PrismicDocument,
+	Field extends LinkField | PrismicDocument | null | undefined =
+		| LinkField
+		| PrismicDocument
+		| null
+		| undefined,
 >(
 	linkFieldOrDocument: Field,
 	linkResolver?: LinkResolverFunction<LinkResolverFunctionReturnType> | null,

--- a/src/asText.ts
+++ b/src/asText.ts
@@ -4,8 +4,8 @@ import { RichTextField } from "@prismicio/types";
 /**
  * The return type of `asText()`.
  */
-type AsTextReturnType<MaybeField extends RichTextField | null | undefined> =
-	MaybeField extends RichTextField ? string : null;
+type AsTextReturnType<Field extends RichTextField | null | undefined> =
+	Field extends RichTextField ? string : null;
 
 /**
  * Serializes a rich text or title field to a plain text string
@@ -16,13 +16,13 @@ type AsTextReturnType<MaybeField extends RichTextField | null | undefined> =
  * @returns Plain text equivalent of the provided rich text or title field
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
-export const asText = <MaybeField extends RichTextField | null | undefined>(
-	richTextField: MaybeField,
+export const asText = <Field extends RichTextField | null | undefined>(
+	richTextField: Field,
 	separator?: string,
-): AsTextReturnType<MaybeField> => {
+): AsTextReturnType<Field> => {
 	if (richTextField) {
-		return baseAsText(richTextField, separator) as AsTextReturnType<MaybeField>;
+		return baseAsText(richTextField, separator) as AsTextReturnType<Field>;
 	} else {
-		return null as AsTextReturnType<MaybeField>;
+		return null as AsTextReturnType<Field>;
 	}
 };

--- a/src/asText.ts
+++ b/src/asText.ts
@@ -2,6 +2,12 @@ import { asText as baseAsText } from "@prismicio/richtext";
 import { RichTextField } from "@prismicio/types";
 
 /**
+ * The return type of `asText()`.
+ */
+type AsTextReturnType<MaybeField extends RichTextField | null | undefined> =
+	MaybeField extends RichTextField ? string : null;
+
+/**
  * Serializes a rich text or title field to a plain text string
  *
  * @param richTextField - A rich text or title field from Prismic
@@ -10,13 +16,13 @@ import { RichTextField } from "@prismicio/types";
  * @returns Plain text equivalent of the provided rich text or title field
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
-export const asText = (
-	richTextField: RichTextField | null | undefined,
+export const asText = <MaybeField extends RichTextField | null | undefined>(
+	richTextField: MaybeField,
 	separator?: string,
-): string | null => {
+): AsTextReturnType<MaybeField> => {
 	if (richTextField) {
-		return baseAsText(richTextField, separator);
+		return baseAsText(richTextField, separator) as AsTextReturnType<MaybeField>;
 	} else {
-		return null;
+		return null as AsTextReturnType<MaybeField>;
 	}
 };

--- a/test/asDate.test.ts
+++ b/test/asDate.test.ts
@@ -2,6 +2,11 @@ import test from "ava";
 
 import { asDate } from "../src";
 
+test("returns null for nullish inputs", (t) => {
+	t.is(asDate(null), null);
+	t.is(asDate(undefined), null);
+});
+
 test("returns null when date field is empty", (t) => {
 	const field = null;
 

--- a/test/asImagePixelDensitySrcSet.test.ts
+++ b/test/asImagePixelDensitySrcSet.test.ts
@@ -3,6 +3,11 @@ import test from "ava";
 
 import { asImagePixelDensitySrcSet } from "../src";
 
+test("returns null for nullish inputs", (t) => {
+	t.is(asImagePixelDensitySrcSet(null), null);
+	t.is(asImagePixelDensitySrcSet(undefined), null);
+});
+
 test("returns an image field pixel-density-based srcset with [1, 2, 3] pxiel densities by default", (t) => {
 	const field: ImageField = {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",

--- a/test/asImageSrc.test.ts
+++ b/test/asImageSrc.test.ts
@@ -3,6 +3,11 @@ import test from "ava";
 
 import { asImageSrc } from "../src";
 
+test("returns null for nullish inputs", (t) => {
+	t.is(asImageSrc(null), null);
+	t.is(asImageSrc(undefined), null);
+});
+
 test("returns an image field URL", (t) => {
 	const field: ImageField = {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",

--- a/test/asImageWidthSrcSet.test.ts
+++ b/test/asImageWidthSrcSet.test.ts
@@ -3,6 +3,11 @@ import test from "ava";
 
 import { asImageWidthSrcSet } from "../src";
 
+test("returns null for nullish inputs", (t) => {
+	t.is(asImageWidthSrcSet(null), null);
+	t.is(asImageWidthSrcSet(undefined), null);
+});
+
 test("returns an image field src and width-based srcset with [640, 750, 828, 1080, 1200, 1920, 2048, 3840] widths by default", (t) => {
 	const field: ImageField = {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",

--- a/test/asLink.test.ts
+++ b/test/asLink.test.ts
@@ -6,11 +6,9 @@ import { linkResolver } from "./__testutils__/linkResolver";
 import { asLink } from "../src";
 import { LinkType } from "@prismicio/types";
 
-test("returns null when link field is falsy", (t) => {
-	const field = undefined;
-
-	// @ts-expect-error testing JavaScript failsafe on purpose
-	t.is(asLink(field, linkResolver), null);
+test("returns null for nullish inputs", (t) => {
+	t.is(asLink(null, linkResolver), null);
+	t.is(asLink(undefined, linkResolver), null);
 });
 
 test("returns null when link to document field is empty", (t) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
This all started when I got back to `@prismicio/vue` and noticed that since then `asText()` and `asHTML()` supported nullish values following: 4c7c8bc95898dd6195b64f9774c6ee34f6917a41 _(sidenote but I don't remember the context and I'm not a fan of it as it's inconsistent with the rest of the API)_

This PR narrows return type of `asDate()`, `asLink()`, `asText()`, `asHTML()` when the field type is known, preventing scenarios such as:
```typescript
// A date field
const date: DateField = "05-23-1999";

// Date is narrowed to type `DateField<"filled">`
if (isFilled.date(date)) {
	// Before: Date | null
	// After: Date
	const dateObject = asDate(date);
}

// A rich text field
const richText: RichTextField = [ /* ... */ ];

// Before: string | null
// After: string
const html = asHTML(date);
```

<!--- Why is this change required? What problem does it solve? -->
I'm not really convinced by the approach, especially since it's really fragile with all the `as` statements but I saw it used with the new image helpers. It's also not really useful with the `asLink()` helper because a filled link can still return null in some cases (user didn't resolve it).
Overall I'm confused at how `isFilled.*` helpers should be used along other helpers if we still have to narrow type after both are used.
May this serve as the ground for a larger discussion around that type narrowing issue 🤔
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐸