### PR TITLE
fix: `isFilled.image()` parameter type

### DIFF
--- a/src/isFilled.ts
+++ b/src/isFilled.ts
@@ -97,9 +97,13 @@ export const imageThumbnail = (
  *
  * @returns `true` if `field` is filled, `false` otherwise.
  */
-export const image = imageThumbnail as <ThumbnailNames extends string | null>(
-	field: ImageField<ThumbnailNames> | null | undefined,
-) => field is ImageField<ThumbnailNames, "filled">;
+export const image = imageThumbnail as <Field extends ImageField>(
+	field:
+		| Field
+		| ImageField<Exclude<keyof Field, number | symbol>>
+		| null
+		| undefined,
+) => field is ImageField<Exclude<keyof Field, number | symbol>, "filled">;
 
 /**
  * Determines if a Link field is filled.

--- a/src/isFilled.ts
+++ b/src/isFilled.ts
@@ -80,7 +80,7 @@ export const title = richText as (
 /**
  * Determines if an Image thumbnail is filled.
  *
- * @param field - Image thumbnail to check.
+ * @param thumbnail - Image thumbnail to check.
  *
  * @returns `true` if `field` is filled, `false` otherwise.
  */
@@ -97,13 +97,15 @@ export const imageThumbnail = (
  *
  * @returns `true` if `field` is filled, `false` otherwise.
  */
-export const image = imageThumbnail as <Field extends ImageField>(
-	field:
-		| Field
-		| ImageField<Exclude<keyof Field, number | symbol>>
-		| null
-		| undefined,
-) => field is ImageField<Exclude<keyof Field, number | symbol>, "filled">;
+export const image = imageThumbnail as <
+	Field extends ImageField,
+	ThumbnailNames extends Exclude<
+		keyof Field,
+		keyof ImageFieldImage | number | symbol
+	>,
+>(
+	field: Field | ImageField<ThumbnailNames> | null | undefined,
+) => field is ImageField<ThumbnailNames, "filled">;
 
 /**
  * Determines if a Link field is filled.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

https://user-images.githubusercontent.com/25330882/157468262-d3576b15-de1d-426c-a572-a59febf8f93e.mp4

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
The image field type is still causing issues, with the `isFilled.image()` helper this time.

I haven't found a proper way of fixing it. The fix present in this PR makes no sense but is _(almost)_ a workaround to the issue. As discussed previously using `infer` like we did in with the `isFilled.embed()` helper does not appear to work here, but feel free to try again!

<details>
<summary>Test results with this PR</summary>
<br />

```typescript
type Doc = {
	image1: ImageField;
	image2: ImageField<"foo">;
	image3: ImageField<"foo" | "bar">;
};

const d: Doc = {
	image1: {},
	image2: { foo: {} },
	image3: { foo: {}, bar: {} },
};

if (image(d.image1)) {
	d.image1.url; // string
} else {
	d.image1.url; // null | undefined
}
if (image(d.image2)) {
	d.image2.url; // string
	d.image2.foo.url; // string
} else {
	d.image2.url; // string | null | undefined, should be null | undefined through
	d.image2.foo.url; // string | null | undefined, should be null | undefined through
}
if (image(d.image3)) {
	d.image3.url; // string
	d.image3.foo.url; // string
	d.image3.bar.url; // string
} else {
	d.image3.url; // string | null | undefined, should be null | undefined through
	d.image3.foo.url; // string | null | undefined, should be null | undefined through
	d.image3.bar.url; // string | null | undefined, should be null | undefined through
}
```

</details>

<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves: #45

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
