### PR TITLE
feat: opt-in automatic responsive view support for `asImageWidthSrcSet()`

### DIFF
--- a/src/asImagePixelDensitySrcSet.ts
+++ b/src/asImagePixelDensitySrcSet.ts
@@ -8,6 +8,20 @@ import {
 import { imageThumbnail as isImageThumbnailFilled } from "./isFilled";
 
 /**
+ * The default pixel densities used to generate a `srcset` value.
+ */
+const DEFAULT_PIXEL_DENSITIES = [1, 2, 3];
+
+/**
+ * Configuration for `asImagePixelDensitySrcSet()`.
+ */
+type AsImagePixelDensitySrcSetConfig = Omit<
+	BuildPixelDensitySrcSetParams,
+	"pixelDensities"
+> &
+	Partial<Pick<BuildPixelDensitySrcSetParams, "pixelDensities">>;
+
+/**
  * The return type of `asImagePixelDensitySrcSet()`.
  */
 type AsImagePixelDensitySrcSetReturnType<
@@ -61,11 +75,12 @@ export const asImagePixelDensitySrcSet = <
 	Field extends ImageFieldImage | null | undefined,
 >(
 	field: Field,
-	params: Omit<BuildPixelDensitySrcSetParams, "pixelDensities"> &
-		Partial<Pick<BuildPixelDensitySrcSetParams, "pixelDensities">> = {},
+	params: AsImagePixelDensitySrcSetConfig = {},
 ): AsImagePixelDensitySrcSetReturnType<Field> => {
 	if (field && isImageThumbnailFilled(field)) {
-		const { pixelDensities = [1, 2, 3], ...imgixParams } = params;
+		// We are using destructuring to omit `pixelDensities` from the
+		// object we will pass to `buildURL()`.
+		const { pixelDensities = DEFAULT_PIXEL_DENSITIES, ...imgixParams } = params;
 
 		return {
 			src: buildURL(field.url, imgixParams),

--- a/src/asImageWidthSrcSet.ts
+++ b/src/asImageWidthSrcSet.ts
@@ -43,11 +43,12 @@ type AsImageWidthSrcSetConfig = Omit<BuildWidthSrcSetParams, "widths"> & {
  * Creates a width-based `srcset` from an Image field with optional image
  * transformations (via Imgix URL parameters).
  *
- * If the Image field contains responsive views, each responsive view is used as
- * a width in the resulting `srcset`.
- *
  * If a `widths` parameter is not given, the following widths will be used by
  * default: 640, 750, 828, 1080, 1200, 1920, 2048, 3840.
+ *
+ * If the Image field contains responsive views, each responsive view can be
+ * used as a width in the resulting `srcset` by passing `"thumbnails"` as the
+ * `widths` parameter.
  *
  * @example
  *
@@ -67,7 +68,8 @@ type AsImageWidthSrcSetConfig = Omit<BuildWidthSrcSetParams, "widths"> & {
  * @param field - Image field (or one of its responsive views) from which to get
  *   an image URL.
  * @param params - An object of Imgix URL API parameters. The `widths` parameter
- *   defines the resulting `srcset` widths.
+ *   defines the resulting `srcset` widths. Pass `"thumbnails"` to automatically
+ *   use the field's responsive views.
  *
  * @returns A `srcset` attribute value for the Image field with Imgix URL
  *   parameters (if given). If the Image field is empty, `null` is returned.

--- a/test/asImageWidthSrcSet.test.ts
+++ b/test/asImageWidthSrcSet.test.ts
@@ -73,7 +73,55 @@ test("applies given Imgix URL parameters", (t) => {
 	);
 });
 
-test("returns a srcset of responsive views if the field contains responsive views", (t) => {
+test('if widths is "auto", returns a srcset of responsive views if the field contains responsive views', (t) => {
+	const field = {
+		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
+		alt: null,
+		copyright: null,
+		dimensions: { width: 1000, height: 800 },
+		foo: {
+			url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
+			alt: null,
+			copyright: null,
+			dimensions: { width: 500, height: 400 },
+		},
+		bar: {
+			url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
+			alt: null,
+			copyright: null,
+			dimensions: { width: 250, height: 200 },
+		},
+	};
+
+	t.deepEqual(asImageWidthSrcSet(field, { widths: "thumbnails" }), {
+		src: field.url,
+		srcset:
+			`${field.url}&width=1000 1000w, ` +
+			`${field.foo.url}&width=500 500w, ` +
+			`${field.bar.url}&width=250 250w`,
+	});
+});
+
+test('if widths is "auto", but the field does not contain responsive views, uses the default widths', (t) => {
+	const field = {
+		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
+		alt: null,
+		copyright: null,
+		dimensions: { width: 1000, height: 800 },
+	};
+
+	t.deepEqual(asImageWidthSrcSet(field, { widths: "thumbnails" }), {
+		src: field.url,
+		srcset:
+			`${field.url}&width=640 640w, ` +
+			`${field.url}&width=828 828w, ` +
+			`${field.url}&width=1200 1200w, ` +
+			`${field.url}&width=2048 2048w, ` +
+			`${field.url}&width=3840 3840w`,
+	});
+});
+
+test('if widths is not "auto", but the field contains responsive views, uses the default widths and ignores thumbnails', (t) => {
 	const field = {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
@@ -96,9 +144,11 @@ test("returns a srcset of responsive views if the field contains responsive view
 	t.deepEqual(asImageWidthSrcSet(field), {
 		src: field.url,
 		srcset:
-			`${field.url}&width=1000 1000w, ` +
-			`${field.foo.url}&width=500 500w, ` +
-			`${field.bar.url}&width=250 250w`,
+			`${field.url}&width=640 640w, ` +
+			`${field.url}&width=828 828w, ` +
+			`${field.url}&width=1200 1200w, ` +
+			`${field.url}&width=2048 2048w, ` +
+			`${field.url}&width=3840 3840w`,
 	});
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates `asImageWidthSrcSet()` to make automatic responsive view support opt-in. Without the changes introduced here, there is no way to opt-out of automatic responsive view support without altering the field's data manually.

Before this PR:

```typescript
asImageWidthSrcSet(fieldWithThumbnails).srcset;
// => A `srcset` value with each thumbnail used as an image URL.

// There is no way to opt-out of automatic responsive view support.
```

After this PR:

```typescript
asImageWidthSrcSet(fieldWithThumbnails).srcset;
// => A `srcset` value for the base image.

asImageWidthSrcSet(fieldWithThumbnails, { widths: "thumbnails" }).srcset;
// => A `srcset` value with each thumbnail used as an image URL.
```

**Important!**: This is technically a breaking change. However, I think we can move forward as a minor version since this is a relatively new API and usage is likely low.

To restore the previous automatic responsive view functionality, pass `"thumbnails"` to the `widths` parameter, like the following example:

```typescript
// Old
asImageWidthSrcSet(fieldWithThumbnails);

// New
asImageWidthSrcSet(fieldWithThumbnails, { widths: "thumbnails" });
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦌
