### PR TITLE
fix: include `url` property when using `asLink()` with a document

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ import {
  * @see Prismic link resolver documentation: {@link https://prismic.io/docs/technologies/link-resolver-javascript}
  */
 export type LinkResolverFunction<ReturnType = string> = (
-	linkToDocumentField: Omit<FilledLinkToDocumentField, "url">,
+	linkToDocumentField: FilledLinkToDocumentField,
 ) => ReturnType;
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates the `LinkResolverFunction` type to include the `url` property.

When Route Resolver and Link Resolver are both used in an app, the `url` property may be filled. This lets developers to check the `url` property in a Link Resolver for something like the following:

```typescript
const linkResolver = (doc) => {
  if (doc.url === "/home") {
    return "/";
  }
};
```

The `asLink()` and `documentToLinkField()` already behaved this way, but the type of `LinkResolverFunction` did not allow it.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🚡
