### PR TITLE
fix: support partial document in `asLink()` and `documentToLinkField()`

### DIFF
--- a/src/documentToLinkField.ts
+++ b/src/documentToLinkField.ts
@@ -35,8 +35,14 @@ export const documentToLinkField = <
 		lang: prismicDocument.lang,
 		url: prismicDocument.url ?? undefined,
 		slug: prismicDocument.slugs?.[0], // Slug field is not available with GraphQl
-		// The REST API does not include a `data` property if the data object is empty.
-		...(Object.keys(prismicDocument.data).length > 0
+		// The REST API does not include a `data` property if the data
+		// object is empty.
+		//
+		// A presence check for `prismicDocument.data` is done to
+		// support partial documents. While `documentToLinkField` is
+		// not typed to accept partial documents, passing a partial
+		// document can happen in untyped projects.
+		...(prismicDocument.data && Object.keys(prismicDocument.data).length > 0
 			? { data: prismicDocument.data }
 			: {}),
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where `asLink()` would throw an error when given a Prismic document without a `data` property.

```typescript
import * as prismicH from "@prismicio/helpers";

asLink({}); // Throws
```

The following error is thrown (the stacktrace has been truncated):

```
TypeError {
  message: 'Cannot convert undefined or null to object',
}

› Function.keys (<anonymous>)
› null.documentToLinkField (node_modules/@prismicio/helpers/src/documentToLinkField.ts:39:14)
› Object.asLink (node_modules/@prismicio/helpers/src/asLink.ts:62:6)
```

This happens because `documentToLinkField()` tries to call `Object.keys()` on `document.data`, which is `undefined`.

Although `asLink()` (and its underlying `documentToLinkField()`) is typed to only accept full Prismic documents, a partial document could be passed in untyped projects.

### Context

The issue this PR solves was discovered while resolving this `@prismicio/react` issue: https://github.com/prismicio/prismic-react/issues/150

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐳
