### PR TITLE
fix: resolve invalid compiled TypeScript types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/richtext": "^2.1.0",
-				"@prismicio/types": "^0.2.0",
+				"@prismicio/types": "^0.2.1",
 				"escape-html": "^1.0.3",
 				"imgix-url-builder": "^0.0.3"
 			},
@@ -319,9 +319,9 @@
 			}
 		},
 		"node_modules/@prismicio/types": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.0.tgz",
-			"integrity": "sha512-xxBSbRzKOYoqjRp+wcaA7aMp0yLp6GQ5QH5hwvLXL0ftVvX8A1pHR3mE6B8kgKgouCC2Ma8XsDRqf+AcfQDbdA==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.1.tgz",
+			"integrity": "sha512-FIj6trxFNlpO7WLYgV6UsURK6tAIXJPoFY9MuNW3eDcdw3he0C/aCRi57ApFiaIyroUSIajPNtWyMYzItD6wSg==",
 			"engines": {
 				"node": ">=12.7.0"
 			}
@@ -6436,9 +6436,9 @@
 			}
 		},
 		"@prismicio/types": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.0.tgz",
-			"integrity": "sha512-xxBSbRzKOYoqjRp+wcaA7aMp0yLp6GQ5QH5hwvLXL0ftVvX8A1pHR3mE6B8kgKgouCC2Ma8XsDRqf+AcfQDbdA=="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.1.tgz",
+			"integrity": "sha512-FIj6trxFNlpO7WLYgV6UsURK6tAIXJPoFY9MuNW3eDcdw3he0C/aCRi57ApFiaIyroUSIajPNtWyMYzItD6wSg=="
 		},
 		"@rollup/plugin-alias": {
 			"version": "3.1.9",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 	},
 	"dependencies": {
 		"@prismicio/richtext": "^2.1.0",
-		"@prismicio/types": "^0.2.0",
+		"@prismicio/types": "^0.2.1",
 		"escape-html": "^1.0.3",
 		"imgix-url-builder": "^0.0.3"
 	},

--- a/src/isFilled.ts
+++ b/src/isFilled.ts
@@ -98,13 +98,9 @@ export const imageThumbnail = (
  * @returns `true` if `field` is filled, `false` otherwise.
  */
 export const image = imageThumbnail as <
-	Field extends ImageField,
-	ThumbnailNames extends Exclude<
-		keyof Field,
-		keyof ImageFieldImage | number | symbol
-	>,
+	ThumbnailNames extends string | null = never,
 >(
-	field: Field | ImageField<ThumbnailNames> | null | undefined,
+	field: ImageField<ThumbnailNames> | null | undefined,
 ) => field is ImageField<ThumbnailNames, "filled">;
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where projects using `@prismicio/helpers`, either directly or as a sub-dependency, and TypeScript could not compile.

See the following issues for more details:

- https://github.com/prismicio/prismic-helpers/issues/55
- https://github.com/prismicio/prismic-client/issues/252

The underlying issue was fixed in https://github.com/prismicio/prismic-types/pull/46. This PR upgrades `@prismicio/types` and simplifies the `isFilled.image()` helper which used the offending TypeScript type.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦌
