### PR TITLE
fix: simplify `isFilled.embed()` for better TypeScript compatibility

### DIFF
--- a/src/isFilled.ts
+++ b/src/isFilled.ts
@@ -228,13 +228,8 @@ export const select = isNonNullish as <Enum extends string>(
  * @returns `true` if `field` is filled, `false` otherwise.
  */
 export const embed = <Field extends EmbedField<AnyOEmbed>>(
-	field:
-		| (Field extends EmbedField<infer Data> ? EmbedField<Data> : never)
-		| null
-		| undefined,
-): field is Field extends EmbedField<infer Data>
-	? EmbedField<Data, "filled">
-	: never => {
+	field: Field | null | undefined,
+): field is Extract<Field, EmbedField<AnyOEmbed, "filled">> => {
 	return isNonNullish(field) && !!field.embed_url;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR simplifies `isFilled.embed()` to fix an issue where certain versions of TypeScript cannot parse `isFilled.embed()`'s bundled type. See #54 for the TypeScript error.

The simplification removes the need for a ternary and `infer` keyword. See the diff to learn what changes were made.

This changes the bundled type like so. Note the lack of `?` in the **After** type.

**Before**:

```typescript
declare const embed: <Field extends {
    [x: string]: never;
} | (AnyOEmbed & {
    embed_url: string;
    html: string | null;
})>(field: (Field extends {
    [x: string]: never;
} | (infer Data extends AnyOEmbed & {
    embed_url: string;
    html: string | null;
}) ? {
    [x: string]: never;
} | (Data & {
    embed_url: string;
    html: string | null;
}) : never) | null | undefined) => field is Field extends {
    [x: string]: never;
} | (infer Data_1 extends AnyOEmbed & {
    embed_url: string;
    html: string | null;
}) ? Data_1 & {
    embed_url: string;
    html: string | null;
} : never;
```

**After**:

```typescript
declare const embed: <
  Field extends
    | {
        [x: string]: never;
      }
    | (AnyOEmbed & {
        embed_url: string;
        html: string | null;
      })
>(
  field: Field | null | undefined
) => field is Extract<
  Field,
  AnyOEmbed & {
    embed_url: string;
    html: string | null;
  }
>;
```

Fixes #54.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦊
