### PR TITLE
fix: allow Content Relationship field's `data` property overrides when using `isFilled` helpers

### DIFF
--- a/src/isFilled.ts
+++ b/src/isFilled.ts
@@ -113,10 +113,9 @@ export const image = imageThumbnail as <
 export const link = <
 	TypeEnum = string,
 	LangEnum = string,
-	DataInterface extends Record<
-		string,
-		AnyRegularField | GroupField | SliceZone
-	> = never,
+	DataInterface extends
+		| Record<string, AnyRegularField | GroupField | SliceZone>
+		| unknown = unknown,
 >(
 	field: LinkField<TypeEnum, LangEnum, DataInterface> | null | undefined,
 ): field is LinkField<TypeEnum, LangEnum, DataInterface, "filled"> => {
@@ -144,10 +143,9 @@ export const linkToMedia = link as (
 export const contentRelationship = link as <
 	TypeEnum = string,
 	LangEnum = string,
-	DataInterface extends Record<
-		string,
-		AnyRegularField | GroupField | SliceZone
-	> = never,
+	DataInterface extends
+		| Record<string, AnyRegularField | GroupField | SliceZone>
+		| unknown = unknown,
 >(
 	field: RelationField<TypeEnum, LangEnum, DataInterface> | null | undefined,
 ) => field is RelationField<TypeEnum, LangEnum, DataInterface, "filled">;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes an issue where types for Link and Content Relationship field's `data` properties were lost after running through `isFilled` helpers.

The `data` property now defaults to `unknown` rather than `never`, allowing for manual type intersections.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
